### PR TITLE
Feat : #8 다이어리 패키지 레포에서 JPA 상속

### DIFF
--- a/server/src/main/java/team21/solsolpokect/diary/repository/DiaryRepository.java
+++ b/server/src/main/java/team21/solsolpokect/diary/repository/DiaryRepository.java
@@ -1,4 +1,7 @@
 package team21.solsolpokect.diary.repository;
 
-public interface DiaryRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import team21.solsolpokect.diary.entity.Diary;
+
+public interface DiaryRepository extends JpaRepository<Diary,Long> {
 }

--- a/server/src/main/java/team21/solsolpokect/diary/repository/FeedbackRepository.java
+++ b/server/src/main/java/team21/solsolpokect/diary/repository/FeedbackRepository.java
@@ -1,4 +1,7 @@
 package team21.solsolpokect.diary.repository;
 
-public interface FeedbackRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import team21.solsolpokect.diary.entity.Feedback;
+
+public interface FeedbackRepository extends JpaRepository<Feedback,Long> {
 }

--- a/server/src/main/java/team21/solsolpokect/diary/repository/MonthlyGoalMoneyRepository.java
+++ b/server/src/main/java/team21/solsolpokect/diary/repository/MonthlyGoalMoneyRepository.java
@@ -1,4 +1,7 @@
 package team21.solsolpokect.diary.repository;
 
-public interface MonthlyGoalMoneyRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import team21.solsolpokect.diary.entity.MonthlyGoalMoney;
+
+public interface MonthlyGoalMoneyRepository extends JpaRepository<MonthlyGoalMoney,Long> {
 }


### PR DESCRIPTION
## 📕 다이어리 패키지 레포에서 JPA 상속

## 📗 작업 내용
DiaryRepository, FeedbackRepository, MonthlyGoalMoneyRepository 레포에 JPA 상속
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#8-Diary-repository -> main

### 변경 사항
- DiaryRepository JPA 상속
- FeedbackRepository JPA 상속
- MonthlyGoalMoneyRepository JPA 상속

### 테스트 결과
테스트 미실시