### PR TITLE
Feat : #10 Mission 패키지 JPA 상속

### DIFF
--- a/server/src/main/java/team21/solsolpokect/mission/repository/MissionRepository.java
+++ b/server/src/main/java/team21/solsolpokect/mission/repository/MissionRepository.java
@@ -1,4 +1,7 @@
 package team21.solsolpokect.mission.repository;
 
-public interface MissionRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import team21.solsolpokect.mission.entity.Mission;
+
+public interface MissionRepository extends JpaRepository<Mission,Long> {
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -1,4 +1,4 @@
 package team21.solsolpokect.mission.service;
 
-public class Mission {
+public class MissionService {
 }


### PR DESCRIPTION
## 📕 Mission 패키지 JPA 상속

## 📗 작업 내용
MissionRepository 클래스에 JPA 상속
클래스명 수정, Mission -> MissionService

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#10-Mission-repository -> main

### 변경 사항
- MissionRepository 클래스에 JPA 상속
- 클래스명 수정, Mission -> MissionService

### 테스트 결과
테스트 미실시