### PR TITLE
Feat/#31 mission service 구현

### DIFF
--- a/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
+++ b/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Getter
 public enum ErrorType {
     NOT_FOUND_USER(401, "등록된 사용자가 없습니다."),
+    NOT_FOUND_MISSION(401, "등록된 도전과제가 없습니다."),
     ;
     private int code;
     private String msg;

--- a/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
+++ b/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 @Getter
 public enum ErrorType {
+    NOT_FOUND_USER(401, "등록된 사용자가 없습니다."),
     ;
     private int code;
     private String msg;

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MissionController {
 
-    MissionService missionService;
+    private final MissionService missionService;
 
     @PostMapping("/create")
     public ApiResponseDto<Long> missionCreate(@RequestBody MissionCreateRequestDto missionCreateRequestDto) {

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -53,9 +53,9 @@ public class MissionController {
     }
 
     @PutMapping("/allow-picture/{mission-id}")
-    public ApiResponseDto<Long> missionAllowPicture(@PathVariable("mission-id") long missionId, @RequestBody MissionPictureRequestDto missionPictureRequestDto) {
-
-        return ResponseUtils.ok(missionService.missionAllowPicture(missionId, missionPictureRequestDto), MsgType.MISSION_ALLOW_PICTURE_SUCCESSFULLY);
+    public ApiResponseDto<Void> missionAllowPicture(@PathVariable("mission-id") long missionId, @RequestBody MissionPictureRequestDto missionPictureRequestDto) {
+        missionService.missionAllowPicture(missionId, missionPictureRequestDto);
+        return ResponseUtils.ok(MsgType.MISSION_ALLOW_PICTURE_SUCCESSFULLY);
     }
 
     @PutMapping("/complete/{mission-id}")

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -59,8 +59,8 @@ public class MissionController {
     }
 
     @PutMapping("/complete/{mission-id}")
-    public ApiResponseDto<Long> missionComplete(@PathVariable("mission-id") long missionId, @RequestBody MissionCompleteRequestDto missionCompleteRequestDto) {
-
-        return ResponseUtils.ok(missionService.missionComplete(missionId, missionCompleteRequestDto), MsgType.MISSION_COMPLETE_SUCCESSFULLY);
+    public ApiResponseDto<Void> missionComplete(@PathVariable("mission-id") long missionId, @RequestBody MissionCompleteRequestDto missionCompleteRequestDto) {
+        missionService.missionComplete(missionId, missionCompleteRequestDto);
+        return ResponseUtils.ok(MsgType.MISSION_COMPLETE_SUCCESSFULLY);
     }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -23,8 +23,9 @@ public class MissionController {
     private final MissionService missionService;
 
     @PostMapping("/create")
-    public ApiResponseDto<Long> missionCreate(@RequestBody MissionCreateRequestDto missionCreateRequestDto) {
-        return ResponseUtils.ok(missionService.missionCreate(missionCreateRequestDto), MsgType.MISSION_CREATE_SUCCESSFULLY);
+    public ApiResponseDto<Void> missionCreate(@RequestBody MissionCreateRequestDto missionCreateRequestDto) {
+        missionService.missionCreate(missionCreateRequestDto);
+        return ResponseUtils.ok(MsgType.MISSION_CREATE_SUCCESSFULLY);
     }
 
     @PutMapping("/allow/{mission-id}")

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -47,9 +47,9 @@ public class MissionController {
     }
 
     @DeleteMapping("/{mission-id}")
-    public ApiResponseDto<Long> missionDelete(@PathVariable("mission-id") long missionId) {
-
-        return ResponseUtils.ok(missionService.missionDelete(missionId), MsgType.MISSION_DELETE_SUCCESSFULLY);
+    public ApiResponseDto<Void> missionDelete(@PathVariable("mission-id") long missionId) {
+        missionService.missionDelete(missionId);
+        return ResponseUtils.ok(MsgType.MISSION_DELETE_SUCCESSFULLY);
     }
 
     @PutMapping("/allow-picture/{mission-id}")

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -29,8 +29,9 @@ public class MissionController {
     }
 
     @PutMapping("/allow/{mission-id}")
-    public ApiResponseDto<Long> missionAllow(@PathVariable("mission-id") long missionId, @RequestBody MissionAllowRequestDto missionAllowRequestDto) {
-        return ResponseUtils.ok(missionService.missionAllow(missionId, missionAllowRequestDto), missionAllowRequestDto.isAllow() ? MsgType.MISSION_ALLOW_SUCCESSFULLY : MsgType.MISSION_REJECT_SUCCESSFULLY);
+    public ApiResponseDto<Void> missionAllow(@PathVariable("mission-id") long missionId, @RequestBody MissionAllowRequestDto missionAllowRequestDto) {
+        missionService.missionAllow(missionId, missionAllowRequestDto);
+        return ResponseUtils.ok(missionAllowRequestDto.isAllow() ? MsgType.MISSION_ALLOW_SUCCESSFULLY : MsgType.MISSION_REJECT_SUCCESSFULLY);
     }
 
     @GetMapping("/list")

--- a/server/src/main/java/team21/solsolpokect/mission/dto/request/MissionCompleteRequestDto.java
+++ b/server/src/main/java/team21/solsolpokect/mission/dto/request/MissionCompleteRequestDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 public class MissionCompleteRequestDto {
 
     private long userId;
-    private boolean allow;
+    private boolean complete;
 }

--- a/server/src/main/java/team21/solsolpokect/mission/dto/response/MissionInfoDetailResponseDto.java
+++ b/server/src/main/java/team21/solsolpokect/mission/dto/response/MissionInfoDetailResponseDto.java
@@ -1,5 +1,6 @@
 package team21.solsolpokect.mission.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -14,4 +15,29 @@ public class MissionInfoDetailResponseDto {
     private String picture;
     private boolean allow;
     private LocalDateTime createdAt;
+
+    @Builder
+    public MissionInfoDetailResponseDto(String missionName, int reward, boolean complete, String goal,
+                                        String picture, boolean allow, LocalDateTime createdAt) {
+        this.missionName = missionName;
+        this.reward = reward;
+        this.complete = complete;
+        this.goal = goal;
+        this.picture = picture;
+        this.allow = allow;
+        this.createdAt = createdAt;
+    }
+
+    public static MissionInfoDetailResponseDto of(String missionName, int reward, boolean complete, String goal,
+                                             String picture, boolean allow, LocalDateTime createdAt) {
+        return builder()
+                .missionName(missionName)
+                .reward(reward)
+                .complete(complete)
+                .goal(goal)
+                .picture(picture)
+                .allow(allow)
+                .createdAt(createdAt)
+                .build();
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/dto/response/MissionInfosResponseDto.java
+++ b/server/src/main/java/team21/solsolpokect/mission/dto/response/MissionInfosResponseDto.java
@@ -1,5 +1,6 @@
 package team21.solsolpokect.mission.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -13,4 +14,26 @@ public class MissionInfosResponseDto {
     private boolean allow;
     private LocalDateTime createdAt;
     private LocalDateTime updateAt;
+
+    @Builder
+    public MissionInfosResponseDto(long missionId, String missionName, boolean complete, boolean allow, LocalDateTime createdAt, LocalDateTime updateAt) {
+        this.missionId = missionId;
+        this.missionName = missionName;
+        this.complete = complete;
+        this.allow = allow;
+        this.createdAt = createdAt;
+        this.updateAt = updateAt;
+    }
+
+    public static MissionInfosResponseDto of(long missionId, String missionName, boolean complete, boolean allow,
+                                             LocalDateTime createdAt, LocalDateTime updateAt) {
+        return builder()
+                .missionId(missionId)
+                .missionName(missionName)
+                .complete(complete)
+                .allow(allow)
+                .createdAt(createdAt)
+                .updateAt(updateAt)
+                .build();
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
+++ b/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team21.solsolpokect.common.entity.BaseTime;
+import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
 import team21.solsolpokect.user.entity.Users;
 
 import javax.persistence.*;
@@ -49,5 +50,15 @@ public class Mission extends BaseTime {
         this.picture = picture;
         this.user = user;
         this.allow = allow;
+    }
+
+    public static Mission of(Users user, String missionName, int reward, boolean complete, String goal) {
+        return builder()
+                .user(user)
+                .missionName(missionName)
+                .reward(reward)
+                .complete(complete)
+                .goal(goal)
+                .build();
     }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
+++ b/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
@@ -61,4 +61,8 @@ public class Mission extends BaseTime {
                 .goal(goal)
                 .build();
     }
+
+    public void updateAllow(boolean allow) {
+        this.allow = allow;
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
+++ b/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
@@ -65,4 +65,8 @@ public class Mission extends BaseTime {
     public void updateAllow(boolean allow) {
         this.allow = allow;
     }
+
+    public void updatePicture(String picture) {
+        this.picture = picture;
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
+++ b/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
@@ -69,4 +69,8 @@ public class Mission extends BaseTime {
     public void updatePicture(String picture) {
         this.picture = picture;
     }
+
+    public void updateComplete(boolean complete) {
+        this.complete = complete;
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/repository/MissionRepository.java
+++ b/server/src/main/java/team21/solsolpokect/mission/repository/MissionRepository.java
@@ -1,7 +1,14 @@
 package team21.solsolpokect.mission.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team21.solsolpokect.mission.entity.Mission;
 
+import java.util.List;
+
 public interface MissionRepository extends JpaRepository<Mission,Long> {
+
+    @Query("SELECT m FROM Mission m WHERE m.user.userId = :userId AND m.deletedDate IS NULL  ORDER BY m.createdAt DESC")
+    List<Mission> findAllByUserId(@Param("userId")Long userId);
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -2,8 +2,11 @@ package team21.solsolpokect.mission.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import team21.solsolpokect.common.exception.CustomException;
 import team21.solsolpokect.common.exception.ErrorType;
+import team21.solsolpokect.mission.dto.request.MissionAllowRequestDto;
 import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
 import team21.solsolpokect.mission.entity.Mission;
 import team21.solsolpokect.mission.repository.MissionRepository;
@@ -28,4 +31,12 @@ public class MissionService {
         missionRepository.save(Mission.of(user.get(), missionCreateRequestDto.getMissionName(), missionCreateRequestDto.getReward(), false, missionCreateRequestDto.getGoal()));
     }
 
+    public void missionAllow(long missionId, MissionAllowRequestDto missionAllowRequestDto) {
+        Optional<Mission> mission = missionRepository.findById(missionId);
+
+        if(mission.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_MISSION);
+
+        mission.get().updateAllow(missionAllowRequestDto.isAllow());
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -1,4 +1,31 @@
 package team21.solsolpokect.mission.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team21.solsolpokect.common.exception.CustomException;
+import team21.solsolpokect.common.exception.ErrorType;
+import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
+import team21.solsolpokect.mission.entity.Mission;
+import team21.solsolpokect.mission.repository.MissionRepository;
+import team21.solsolpokect.user.entity.Users;
+import team21.solsolpokect.user.repository.UsersRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
 public class MissionService {
+
+    private final MissionRepository missionRepository;
+    private final UsersRepository usersRepository;
+
+    public void missionCreate(MissionCreateRequestDto missionCreateRequestDto) {
+        Optional<Users> user = usersRepository.findById(missionCreateRequestDto.getUserId());
+
+        if(user.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_USER);
+
+        missionRepository.save(Mission.of(user.get(), missionCreateRequestDto.getMissionName(), missionCreateRequestDto.getReward(), false, missionCreateRequestDto.getGoal()));
+    }
+
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -90,4 +90,6 @@ public class MissionService {
 
         mission.get().updatePicture(missionPictureRequestDto.getPicture());
     }
+
+
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -14,6 +14,7 @@ import team21.solsolpokect.mission.repository.MissionRepository;
 import team21.solsolpokect.user.entity.Users;
 import team21.solsolpokect.user.repository.UsersRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,7 +49,14 @@ public class MissionService {
         if(user.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_USER);
 
-        return missionRepository.findAllByUserId(userId);
+        List<Mission> missions = missionRepository.findAllByUserId(userId);
+        List<MissionInfosResponseDto> missionInfosResponseDtos = new ArrayList<>();
 
+        for (Mission m : missions) {
+            missionInfosResponseDtos.add(MissionInfosResponseDto.of(m.getId(), m.getMissionName(), m.isComplete(),
+                    m.isAllow(), m.getCreatedAt(), m.getUpdateAt()));
+        }
+
+        return missionInfosResponseDtos;
     }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import team21.solsolpokect.common.exception.CustomException;
 import team21.solsolpokect.common.exception.ErrorType;
+import team21.solsolpokect.common.response.ApiResponseDto;
 import team21.solsolpokect.mission.dto.request.MissionAllowRequestDto;
 import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
+import team21.solsolpokect.mission.dto.response.MissionInfoDetailResponseDto;
 import team21.solsolpokect.mission.dto.response.MissionInfosResponseDto;
 import team21.solsolpokect.mission.entity.Mission;
 import team21.solsolpokect.mission.repository.MissionRepository;
@@ -58,5 +60,15 @@ public class MissionService {
         }
 
         return missionInfosResponseDtos;
+    }
+
+    public MissionInfoDetailResponseDto missionDetail(long missionId) {
+        Optional<Mission> mission = missionRepository.findById(missionId);
+
+        if(mission.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_MISSION);
+
+        return MissionInfoDetailResponseDto.of(mission.get().getMissionName(), mission.get().getReward() , mission.get().isComplete(),
+                mission.get().getGoal(), mission.get().getPicture(), mission.get().isAllow(), mission.get().getCreatedAt());
     }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -71,4 +71,13 @@ public class MissionService {
         return MissionInfoDetailResponseDto.of(mission.get().getMissionName(), mission.get().getReward() , mission.get().isComplete(),
                 mission.get().getGoal(), mission.get().getPicture(), mission.get().isAllow(), mission.get().getCreatedAt());
     }
+
+    public void missionDelete(long missionId) {
+        Optional<Mission> mission = missionRepository.findById(missionId);
+
+        if(mission.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_MISSION);
+
+        missionRepository.delete(mission.get());
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -8,11 +8,13 @@ import team21.solsolpokect.common.exception.CustomException;
 import team21.solsolpokect.common.exception.ErrorType;
 import team21.solsolpokect.mission.dto.request.MissionAllowRequestDto;
 import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
+import team21.solsolpokect.mission.dto.response.MissionInfosResponseDto;
 import team21.solsolpokect.mission.entity.Mission;
 import team21.solsolpokect.mission.repository.MissionRepository;
 import team21.solsolpokect.user.entity.Users;
 import team21.solsolpokect.user.repository.UsersRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -38,5 +40,15 @@ public class MissionService {
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
 
         mission.get().updateAllow(missionAllowRequestDto.isAllow());
+    }
+
+    public List<MissionInfosResponseDto> missionList(long userId) {
+        Optional<Users> user = usersRepository.findById(userId);
+
+        if(user.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_USER);
+
+        return missionRepository.findAllByUserId(userId);
+
     }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -2,12 +2,10 @@ package team21.solsolpokect.mission.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import team21.solsolpokect.common.exception.CustomException;
 import team21.solsolpokect.common.exception.ErrorType;
-import team21.solsolpokect.common.response.ApiResponseDto;
 import team21.solsolpokect.mission.dto.request.MissionAllowRequestDto;
+import team21.solsolpokect.mission.dto.request.MissionCompleteRequestDto;
 import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
 import team21.solsolpokect.mission.dto.request.MissionPictureRequestDto;
 import team21.solsolpokect.mission.dto.response.MissionInfoDetailResponseDto;
@@ -91,5 +89,12 @@ public class MissionService {
         mission.get().updatePicture(missionPictureRequestDto.getPicture());
     }
 
+    public void missionComplete(long missionId, MissionCompleteRequestDto missionCompleteRequestDto) {
+        Optional<Mission> mission = missionRepository.findById(missionId);
 
+        if(mission.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_MISSION);
+
+        mission.get().updateComplete(missionCompleteRequestDto.isComplete());
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -9,6 +9,7 @@ import team21.solsolpokect.common.exception.ErrorType;
 import team21.solsolpokect.common.response.ApiResponseDto;
 import team21.solsolpokect.mission.dto.request.MissionAllowRequestDto;
 import team21.solsolpokect.mission.dto.request.MissionCreateRequestDto;
+import team21.solsolpokect.mission.dto.request.MissionPictureRequestDto;
 import team21.solsolpokect.mission.dto.response.MissionInfoDetailResponseDto;
 import team21.solsolpokect.mission.dto.response.MissionInfosResponseDto;
 import team21.solsolpokect.mission.entity.Mission;
@@ -79,5 +80,14 @@ public class MissionService {
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
 
         missionRepository.delete(mission.get());
+    }
+
+    public void missionAllowPicture(long missionId, MissionPictureRequestDto missionPictureRequestDto) {
+        Optional<Mission> mission = missionRepository.findById(missionId);
+
+        if(mission.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_MISSION);
+
+        mission.get().updatePicture(missionPictureRequestDto.getPicture());
     }
 }

--- a/server/src/main/java/team21/solsolpokect/transfer/entity/AutoTransfer.java
+++ b/server/src/main/java/team21/solsolpokect/transfer/entity/AutoTransfer.java
@@ -26,14 +26,14 @@ public class AutoTransfer extends BaseTime {
     private int money;
 
     @Column(nullable = false)
-    private int childAccount;
+    private String childAccount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)
     private Users user;
 
     @Builder
-    public AutoTransfer(LocalDateTime autoDate, int money, int childAccount, Users user) {
+    public AutoTransfer(LocalDateTime autoDate, int money, String childAccount, Users user) {
         this.autoDate = autoDate;
         this.money = money;
         this.childAccount = childAccount;

--- a/server/src/main/java/team21/solsolpokect/user/entity/Users.java
+++ b/server/src/main/java/team21/solsolpokect/user/entity/Users.java
@@ -29,7 +29,7 @@ public class Users extends BaseTime {
     private Family family;
 
     @Column(nullable = false)
-    private int account;
+    private String account;
 
     @Column(nullable = false, length = 30)
     private String userId;
@@ -41,7 +41,7 @@ public class Users extends BaseTime {
     private int creditScore;
 
     @Builder
-    public Users(String role, String userName, Family family, int account, String userId, String password, int creditScore) {
+    public Users(String role, String userName, Family family, String account, String userId, String password, int creditScore) {
         this.role = role;
         this.userName = userName;
         this.family = family;

--- a/server/src/main/java/team21/solsolpokect/user/repository/UsersRepository.java
+++ b/server/src/main/java/team21/solsolpokect/user/repository/UsersRepository.java
@@ -1,4 +1,7 @@
 package team21.solsolpokect.user.repository;
 
-public interface UsersRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import team21.solsolpokect.user.entity.Users;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
 }


### PR DESCRIPTION
## 📕 Feat/#31 mission service 구현

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#31-MissionServic -> main

### 변경 사항
- missionCreate service 구현
- missionAllow service 구현
- missionList service 구현
- missionDetail service 구현
- missionDelete service 구현
- missionAllowPicture service 구현
- missionComplete service 구현

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
