### PR TITLE
Fix : 다이어리 및 로그인 수정

### DIFF
--- a/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
+++ b/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
@@ -15,7 +15,9 @@ public enum ErrorType {
     NOT_TOKEN(401, "토큰이 없습니다."),
     NOT_VALID_TOKEN(401, "토큰이 유효하지 않습니다."),
     NOT_FOUND_DIARY(401, "등록된 가계부가 없습니다."),
-    TODAY_IS_NOT_SUNDAY(401, "오늘은 일요일이 아닙니다.");
+    TODAY_IS_NOT_SUNDAY(401, "오늘은 일요일이 아닙니다."),
+    NOT_MATCHING_ROLE(401, "역할이 맞지 않습니다"),
+    ;
     private int code;
     private String msg;
 

--- a/server/src/main/java/team21/solsolpokect/diary/dto/request/monthlygoal/MonthlyGoalMoneyRequestDto.java
+++ b/server/src/main/java/team21/solsolpokect/diary/dto/request/monthlygoal/MonthlyGoalMoneyRequestDto.java
@@ -2,12 +2,12 @@ package team21.solsolpokect.diary.dto.request.monthlygoal;
 
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 public class MonthlyGoalMoneyRequestDto {
 
-    private LocalDateTime date;
+    private LocalDate date;
     private int goalMoney;
-    private String userId;
+    private Long userId;
 }

--- a/server/src/main/java/team21/solsolpokect/diary/entity/MonthlyGoalMoney.java
+++ b/server/src/main/java/team21/solsolpokect/diary/entity/MonthlyGoalMoney.java
@@ -1,12 +1,13 @@
 package team21.solsolpokect.diary.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team21.solsolpokect.user.entity.Users;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -17,7 +18,7 @@ public class MonthlyGoalMoney {
     private Long id;
 
     @Column(nullable = false)
-    private LocalDateTime date;
+    private LocalDate date;
 
     @Column(nullable = false)
     private int dailyScore;
@@ -25,4 +26,20 @@ public class MonthlyGoalMoney {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private Users users;
+
+    @Builder
+    private MonthlyGoalMoney(Long id, LocalDate date, int dailyScore, Users users) {
+        this.id = id;
+        this.date = date;
+        this.dailyScore = dailyScore;
+        this.users = users;
+    }
+
+    public static MonthlyGoalMoney of(LocalDate now, int goalMoney, Users users) {
+        return builder()
+                .date(now)
+                .dailyScore(goalMoney)
+                .users(users)
+                .build();
+    }
 }

--- a/server/src/main/java/team21/solsolpokect/diary/service/MonthlyGoalMoneyService.java
+++ b/server/src/main/java/team21/solsolpokect/diary/service/MonthlyGoalMoneyService.java
@@ -3,18 +3,33 @@ package team21.solsolpokect.diary.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team21.solsolpokect.common.exception.CustomException;
+import team21.solsolpokect.common.exception.ErrorType;
 import team21.solsolpokect.diary.dto.request.monthlygoal.MonthlyGoalMoneyRequestDto;
+import team21.solsolpokect.diary.entity.MonthlyGoalMoney;
 import team21.solsolpokect.diary.repository.MonthlyGoalMoneyRepository;
+import team21.solsolpokect.user.entity.Users;
+import team21.solsolpokect.user.repository.UsersRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MonthlyGoalMoneyService {
 
-    private final MonthlyGoalMoneyRepository repository;
+    private final MonthlyGoalMoneyRepository monthlyGoalMoneyRepository;
+    private final UsersRepository usersRepository;
 
     public void goalMoneyCreate(MonthlyGoalMoneyRequestDto requestDto) {
-
-
+        Optional<Users> users = usersRepository.findByIdAndDeletedAtIsNull(requestDto.getUserId());
+        if(users.isEmpty()) throw new CustomException(ErrorType.NOT_FOUND_USER);
+        if(!users.get().getRole().equals("부모")){
+            throw new CustomException(ErrorType.NOT_MATCHING_ROLE);
+        }
+        LocalDate now = requestDto.getDate();
+        MonthlyGoalMoney monthlyGoalMoney = MonthlyGoalMoney.of(now, requestDto.getGoalMoney(), users.get());
+        monthlyGoalMoneyRepository.save(monthlyGoalMoney);
     }
 }

--- a/server/src/main/java/team21/solsolpokect/user/controller/UsersController.java
+++ b/server/src/main/java/team21/solsolpokect/user/controller/UsersController.java
@@ -28,10 +28,10 @@ public class UsersController {
     }
 
     @PostMapping("/login")
-    public ApiResponseDto<Void> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response){
+    public ApiResponseDto<UsersInfoResponseDto> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response){
 
-        usersService.login(requestDto,response);
-        return ResponseUtils.ok(MsgType.LOGIN_SUCCESSFULLY);
+
+        return ResponseUtils.ok(usersService.login(requestDto,response), MsgType.LOGIN_SUCCESSFULLY);
     }
 
     @GetMapping("/info/{user-id}")


### PR DESCRIPTION
## 📕 다이어리 및 로그인 수정

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#74-diary-login-fix -> main

### 변경 사항
- 가계부 해당 날짜만 조회하게 수정
- 로그인 반환 타입 수정
- 월별 목표 금액 설정 API 초기 구현 완료

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
월별 목표 금액 설정은 테스트 미 실시
