### PR TITLE
Feat/#111 mission allow

### DIFF
--- a/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
+++ b/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
     NOT_FOUND_FEEDBACK(401, "등록된 피드백이 없습니다."),
     NOT_FOUND_AUTO_TRANSFER(401, "등록된 자동이체가 없습니다"),
     NOT_FOUND_FAMILY(401, "등록된 가족이 없습니다"),
+    NOT_MATCHING_FAMILY(401, "가족 정보가 일치하지 않습니다."),
     PICTURE_IS_NULL(400, "이미지가 첨부되지 않았습니다."),
     ALREADY_EXIST_USERID(401, "이미 존재하는 아이디입니다."),
     NOT_MATCHING_INFO(401, "회원 정보가 일치하지 않습니다."),

--- a/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
+++ b/server/src/main/java/team21/solsolpokect/common/exception/ErrorType.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 public enum ErrorType {
 
     NOT_FOUND_USER(401, "등록된 사용자가 없습니다."),
+    NOT_VALID_USER(401, "등록된 사용자가 유효하지 않습니다."),
     NOT_FOUND_MISSION(401, "등록된 도전과제가 없습니다."),
+    NOT_CREATE_MISSION(401, "해당 도전과제를 만들 수 없습니다."),
     NOT_FOUND_FEEDBACK(401, "등록된 피드백이 없습니다."),
     NOT_FOUND_AUTO_TRANSFER(401, "등록된 자동이체가 없습니다"),
     NOT_FOUND_FAMILY(401, "등록된 가족이 없습니다"),

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -53,17 +53,16 @@ public class MissionController {
         return ResponseUtils.ok(MsgType.MISSION_DELETE_SUCCESSFULLY);
     }
 
-    @PutMapping("/allow-picture/{mission-id}/{user-id}")
-    public ApiResponseDto<Void> missionAllowPicture(@PathVariable("mission-id") Long missionId, @PathVariable("user-id") long userId,
+    @PutMapping("/allow-picture/{user-id}/{mission-id}")
+    public ApiResponseDto<Void> missionAllowPicture(@PathVariable("user-id") long userId, @PathVariable("mission-id") Long missionId,
                                                     @RequestPart MultipartFile picture) throws IOException {
-        System.out.println("mission id : " + missionId + "user id : " + userId);
         missionService.missionAllowPicture(missionId, userId, picture);
         return ResponseUtils.ok(MsgType.MISSION_ALLOW_PICTURE_SUCCESSFULLY);
     }
 
-    @PutMapping("/complete/{mission-id}")
-    public ApiResponseDto<Void> missionComplete(@PathVariable("mission-id") Long missionId, @RequestBody MissionCompleteRequestDto missionCompleteRequestDto) {
-        missionService.missionComplete(missionId, missionCompleteRequestDto);
+    @PutMapping("/complete/{user-id}/{mission-id}")
+    public ApiResponseDto<Void> missionComplete(@PathVariable("user-id") long userId, @PathVariable("mission-id") Long missionId, @RequestBody MissionCompleteRequestDto missionCompleteRequestDto) {
+        missionService.missionComplete(userId, missionId, missionCompleteRequestDto);
         return ResponseUtils.ok(MsgType.MISSION_COMPLETE_SUCCESSFULLY);
     }
 }

--- a/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
+++ b/server/src/main/java/team21/solsolpokect/mission/controller/MissionController.java
@@ -47,9 +47,9 @@ public class MissionController {
         return ResponseUtils.ok(missionService.missionDetail(missionId), MsgType.MISSION_DETAIL_SUCCESSFULLY);
     }
 
-    @DeleteMapping("/{mission-id}")
-    public ApiResponseDto<Void> missionDelete(@PathVariable("mission-id") Long missionId) {
-        missionService.missionDelete(missionId);
+    @DeleteMapping("/{user-id}/{mission-id}")
+    public ApiResponseDto<Void> missionDelete(@PathVariable("user-id") Long userId, @PathVariable("mission-id") Long missionId) {
+        missionService.missionDelete(userId, missionId);
         return ResponseUtils.ok(MsgType.MISSION_DELETE_SUCCESSFULLY);
     }
 

--- a/server/src/main/java/team21/solsolpokect/mission/dto/request/MissionAllowRequestDto.java
+++ b/server/src/main/java/team21/solsolpokect/mission/dto/request/MissionAllowRequestDto.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public class MissionAllowRequestDto {
 
-    private long userId;
+    private Long userId;
     private boolean allow;
 }

--- a/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
+++ b/server/src/main/java/team21/solsolpokect/mission/entity/Mission.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import team21.solsolpokect.common.entity.BaseTime;
 import team21.solsolpokect.user.entity.Users;
 
@@ -12,6 +13,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE mission set deleted_at = CONVERT_TZ(NOW(), 'UTC', 'Asia/Seoul') where id = ?")
 public class Mission extends BaseTime {
 
     @Id

--- a/server/src/main/java/team21/solsolpokect/mission/repository/MissionRepository.java
+++ b/server/src/main/java/team21/solsolpokect/mission/repository/MissionRepository.java
@@ -1,12 +1,13 @@
 package team21.solsolpokect.mission.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import team21.solsolpokect.mission.entity.Mission;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission,Long> {
 
     List<Mission> findAllByUserIdAndDeletedAtIsNull(Long userId);
+    Optional<Mission> findByIdAndDeletedAtIsNull(Long missionId);
 }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -129,11 +129,28 @@ public class MissionService {
                 mission.get().getGoal(), mission.get().getPicture(), mission.get().isAllow(), mission.get().getCreatedAt(), mission.get().getCategory());
     }
 
-    public void missionDelete(Long missionId) {
+    public void missionDelete(Long userId, Long missionId) {
         Optional<Mission> mission = missionRepository.findByIdAndDeletedAtIsNull(missionId);
-
         if(mission.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
+
+        //현재 로그인한 사용자
+        Optional<Users> user = usersRepository.findByIdAndDeletedAtIsNull(userId);
+        if(user.isEmpty())
+            throw new CustomException(ErrorType.NOT_FOUND_USER);
+
+        //미션을 할 사용자
+        Users child = mission.get().getUser();
+        if(child == null)
+            throw new CustomException(ErrorType.NOT_FOUND_USER);
+
+//        다른 가족인 경우
+        if(user.get().getFamily().getId().equals(child.getFamily().getId()))
+            throw new CustomException(ErrorType.NOT_MATCHING_FAMILY);
+
+//        자신이 자식이고, 같은 가족이나 자신이 아닌 자식인 경우
+        if(user.get().getRole().equals("자녀") && !user.get().getId().equals(child.getId()))
+            throw new CustomException(ErrorType.NOT_MATCHING_INFO);
 
         missionRepository.delete(mission.get());
     }

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -32,8 +32,8 @@ public class MissionService {
     private final S3Uploader s3Uploader;
 
     public void missionCreate(Long userId, MissionCreateRequestDto missionCreateRequestDto) {
-        Optional<Users> child = usersRepository.findById(missionCreateRequestDto.getUserId()); //자녀
-        Optional<Users> user = usersRepository.findById(userId); //현재 로그인 사용자
+        Optional<Users> child = usersRepository.findByIdAndDeletedAtIsNull(missionCreateRequestDto.getUserId()); //자녀
+        Optional<Users> user = usersRepository.findByIdAndDeletedAtIsNull(userId); //현재 로그인 사용자
 
 
         if(child.isEmpty() || user.isEmpty())
@@ -47,7 +47,7 @@ public class MissionService {
     }
 
     public void missionAllow(long missionId, MissionAllowRequestDto missionAllowRequestDto) {
-        Optional<Mission> mission = missionRepository.findById(missionId);
+        Optional<Mission> mission = missionRepository.findByIdAndDeletedAtIsNull(missionId);
 
         if(mission.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
@@ -56,7 +56,7 @@ public class MissionService {
     }
 
     public List<MissionInfosResponseDto> missionList(long userId) {
-        Optional<Users> user = usersRepository.findById(userId);
+        Optional<Users> user = usersRepository.findByIdAndDeletedAtIsNull(userId);
 
         if(user.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_USER);
@@ -89,7 +89,7 @@ public class MissionService {
     }
 
     public MissionInfoDetailResponseDto missionDetail(long missionId) {
-        Optional<Mission> mission = missionRepository.findById(missionId);
+        Optional<Mission> mission = missionRepository.findByIdAndDeletedAtIsNull(missionId);
 
         if(mission.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
@@ -99,7 +99,7 @@ public class MissionService {
     }
 
     public void missionDelete(long missionId) {
-        Optional<Mission> mission = missionRepository.findById(missionId);
+        Optional<Mission> mission = missionRepository.findByIdAndDeletedAtIsNull(missionId);
 
         if(mission.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
@@ -108,7 +108,7 @@ public class MissionService {
     }
 
     public void missionAllowPicture(long missionId, long userId, MultipartFile picture) throws IOException {
-        Optional<Mission> mission = missionRepository.findById(missionId);
+        Optional<Mission> mission = missionRepository.findByIdAndDeletedAtIsNull(missionId);
 
         if(mission.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);
@@ -126,7 +126,7 @@ public class MissionService {
     }
 
     public void missionComplete(long missionId, MissionCompleteRequestDto missionCompleteRequestDto) {
-        Optional<Mission> mission = missionRepository.findById(missionId);
+        Optional<Mission> mission = missionRepository.findByIdAndDeletedAtIsNull(missionId);
 
         if(mission.isEmpty())
             throw new CustomException(ErrorType.NOT_FOUND_MISSION);

--- a/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
+++ b/server/src/main/java/team21/solsolpokect/mission/service/MissionService.java
@@ -48,7 +48,6 @@ public class MissionService {
             throw new CustomException(ErrorType.NOT_MATCHING_ROLE);
 
         boolean allow = false;
-        //미션 작성자의 role
         if(user.get().getRole().equals("부모")) {
                 if(!child.get().getFamily().getId().equals(user.get().getFamily().getId()))
                     throw new CustomException(ErrorType.NOT_FOUND_FAMILY);

--- a/server/src/main/java/team21/solsolpokect/user/entity/Users.java
+++ b/server/src/main/java/team21/solsolpokect/user/entity/Users.java
@@ -18,7 +18,7 @@ public class Users extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(nullable = false, length = 10)
     private String role;


### PR DESCRIPTION
## 📕 mission 권한 확인 기능 추가

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#111-missionAllow -> main

### 변경 사항
- missionAllow 거부시 도전과제 삭제 기능
- mission 도메인 findById -> findAllByIdAndDeletedAtIsNull 수정
- missionAllow시 권한 확인 기능
- missionCreate 권한 확인 기능
- missionDelete 권한 확인 기능
- missionComplete 권한 확인 기능

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
